### PR TITLE
install jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && \
     apk upgrade && \
     apk add git && \
     apk add go && \
+    apk add jq && \
     apk add make && \
     apk add make && \
     apk add rsync && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update && \
     apk add go && \
     apk add jq && \
     apk add make && \
-    apk add make && \
     apk add rsync && \
     git clone https://github.com/cli/cli.git gh-cli && \
     cd gh-cli && \


### PR DESCRIPTION
- Got this error while doing the latest release: https://github.com/CartoDB/cloud-native/runs/4759783078?check_suite_focus=true
- Basically, jq is not installed but it's required.